### PR TITLE
truststore_nss: add firefox nightly and developer edition binary path…

### DIFF
--- a/truststore_nss.go
+++ b/truststore_nss.go
@@ -24,7 +24,10 @@ var (
 		"/etc/pki/nssdb", // CentOS 7
 	}
 	firefoxPaths = []string{
-		"/usr/bin/firefox", "/Applications/Firefox.app",
+		"/usr/bin/firefox",
+		"/usr/bin/firefox-nightly",
+		"/usr/bin/firefox-developer-edition",
+		"/Applications/Firefox.app",
 		"/Applications/Firefox Developer Edition.app",
 		"/Applications/Firefox Nightly.app",
 		"C:\\Program Files\\Mozilla Firefox",


### PR DESCRIPTION
…s (#225)

on my system I have only Firefox Nightly installed, so `/usr/bin/firefox` doesn't exist and so `hasNSS` was false and CA wasn't installed.

on my arch based system, the binary was at `/usr/bin/firefox-nightly`
https://aur.archlinux.org/packages/firefox-nightly/
it could also be at `/usr/bin/firefox-developer-edition`
see "package contents"
https://www.archlinux.org/packages/community/x86_64/firefox-developer-edition/